### PR TITLE
If request is an absolute path, strip path to match

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var fs = require("fs");
+var path = require("path");
 
 function contains(arr, val) {
     return arr && arr.indexOf(val) !== -1;
@@ -57,7 +58,8 @@ module.exports = function nodeExternals(options) {
 
     // return an externals function
     return function(context, request, callback) {
-        var pathStart = request.split('/')[0];
+        var req = (path.isAbsolute(request) && request.indexOf(modulesDir) > 0) ? request.split(modulesDir + '/')[1] : request;
+        var pathStart = req.split('/')[0];
         if (contains(nodeModules, pathStart) && !containsPattern(whitelist, request)) {
             // mark this module as external
             // https://webpack.github.io/docs/configuration.html#externals


### PR DESCRIPTION
I came across an issue when building webpack on my CI server Ubuntu machine that instead of `request` being the module name itself, it returned the absolute path to the module resulting in the bundle not including the externals and leading to errors on the user side.

The check for an absolute path seems like the simplest solution to me, and I'm definitely open to other suggestions and would happily update the pull request.