### PR TITLE
Changed location of package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function readDir(dirName) {
 function readFromPackageJson() {
     var packageJson;
     try {
-        packageJson = require('./package.json');
+        packageJson = require(process.cwd() + '/package.json');
     } catch (e){
         return [];
     }


### PR DESCRIPTION
The require for the package.json was looking in the current module directory ie "webpack-node-externals" so the result was always  the same 3 dependencies [ 'chai', 'mocha', 'mock-fs' ]. Changed the require to look for the package.json in the same directory as the process was ran from.