### PR TITLE
Use map, reduce instead of double forEach

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,13 +21,15 @@ function readFromPackageJson() {
         return [];
     }
     var sections = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
-    var deps = {};
-    sections.forEach(function(section){
-        Object.keys(packageJson[section] || {}).forEach(function(dep){
-            deps[dep] = true;
-        });
-    });
-    return Object.keys(deps);
+    var deps = sections
+      .map(function(section){
+        return Object.keys(packageJson[section] || {});
+      })
+      .reduce(function(allDeps, depsInSection){
+        return allDeps.concat(depsInSection);
+      }, []);
+
+    return deps;
 }
 
 function containsPattern(arr, val) {

--- a/index.js
+++ b/index.js
@@ -21,14 +21,12 @@ function readFromPackageJson() {
         return [];
     }
     var sections = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
-    var deps = sections
-      .map(function(section){
-        return Object.keys(packageJson[section] || {});
-      })
-      .reduce(function(allDeps, depsInSection){
-        return allDeps.concat(depsInSection);
-      }, []);
+    var deps = [];
+    sections.forEach(function(section){
+      var packages = Object.keys(packageJson[section] || {});
 
+      deps = deps.concat(packages);
+    });
     return deps;
 }
 


### PR DESCRIPTION
When I was reading the code to figure out how 'webpack-node-externals' works, I came up with idea that map, reduce methods are better than double forEach to get the dependencies from package.json.
I'm a beginner in Javascript. I'm open to other suggestions and happy to learn more from it:D 