### PR TITLE
Added support for scoped packages

### DIFF
--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -16,6 +16,7 @@ describe('invocation with no settings', function() {
     describe('should invoke a commonjs callback', function(){
         it('when given an existing module', assertResult('moduleA', 'commonjs moduleA'));
         it('when given another existing module', assertResult('moduleB', 'commonjs moduleB'));
+        it('when given another existing module for scoped package', assertResult('@organisation/moduleA', 'commonjs @organisation/moduleA'));
         it('when given an existing sub-module', assertResult('moduleA/sub-module', 'commonjs moduleA/sub-module'));
         it('when given an existing file in a sub-module', assertResult('moduleA/another-sub/index.js', 'commonjs moduleA/another-sub/index.js'));
     });
@@ -133,10 +134,12 @@ describe('invocation with an absolute path setting', function() {
     describe('should invoke a commonjs callback', function(){
         it('when given an existing module', assertResult('moduleA', 'commonjs moduleA'));
         it('when given another existing module', assertResult('moduleB', 'commonjs moduleB'));
+        it('when given another existing module for scoped package', assertResult('@organisation/moduleA', 'commonjs @organisation/moduleA'));
         it('when given an existing sub-module', assertResult('moduleA/sub-module', 'commonjs moduleA/sub-module'));
         it('when given an existing file in a sub-module', assertResult('moduleA/another-sub/index.js', 'commonjs moduleA/another-sub/index.js'));
         it('when given an absolute path', assertResult('/test/node_modules/moduleA', 'commonjs /test/node_modules/moduleA'));
         it('when given another absolute path', assertResult('../../test/node_modules/moduleA', 'commonjs ../../test/node_modules/moduleA'));
+        it('when given another absolute path for scoped package', assertResult('/test/node_modules/@organisation/moduleA', 'commonjs /test/node_modules/@organisation/moduleA'));
         it('when given an existing sub-module inside node_modules', assertResult('/moduleA/node_modules/moduleB', 'commonjs /moduleA/node_modules/moduleB'));
     });
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -45,6 +45,7 @@ exports.mockNodeModules = function mockNodeModules(structure){
             'sub-module':{}
         },
         'moduleF' : {},
+        '@organisation/moduleA':{},
     };
 
     mockDir({


### PR DESCRIPTION
## Overview
At present, if you try and require a [scoped package](https://docs.npmjs.com/misc/scope) the scoped module is stripped when determining the module name. 

e.g. `@organisation/moduleA` would become `@organisation` 

This PR implements a scoped module check and returns the correct module name if it matches. I've refactored the functionality so all checks occur in the getModuleName function.