### PR TITLE
support custom importType format

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ An array for the `externals` to whitelist, so they **will** be included in the b
 
 #### `options.importType (='commonjs')`
 The method in which unbundled modules will be required in the code. Best to leave as `commonjs` for node modules.
+May be one of [documented options](https://webpack.github.io/docs/configuration.html#externals) or function `callback(moduleName)` which returns custom code to be returned as import type, eg.:
+```js
+options.importType = function (moduleName) {
+    return "window['" + moduleName + "'];"
+}
+```
 
 #### `options.modulesDir (='node_modules')`
 The folder in which to search for the node modules.

--- a/index.js
+++ b/index.js
@@ -100,8 +100,11 @@ module.exports = function nodeExternals(options) {
         if (contains(nodeModules, moduleName) && !containsPattern(whitelist, request)) {
             // mark this module as external
             // https://webpack.github.io/docs/configuration.html#externals
+            if (typeof importType === 'function') {
+                return callback(null, importType(request));
+            }
             return callback(null, importType + " " + request);
-        };
+        }
         callback();
     }
-}
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-node-externals",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Easily exclude node_modules in Webpack bundle",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Among few documented options, webpack also supports custom strings to be used as-is.