### PR TITLE
Introduce `modulesDirs` option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: node_js
-before_install:
-  - "npm install npm -g"
 node_js:
   - "0.12"
   - 5
   - 6
 env:
   - TEST_SUITE=unit
-script: 
+script:
   - npm run $TEST_SUITE

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ The method in which unbundled modules will be required in the code. Best to leav
 #### `options.modulesDir (='node_modules')`
 The folder in which to search for the node modules.
 
+#### `options.modulesDirs (=['node_modules'])`
+An array of folder in which to search for the node modules.
+
 #### `options.modulesFromFile (=false)`
 Read the modules from the `package.json` file instead of the `node_modules` folder.
 

--- a/index.js
+++ b/index.js
@@ -82,7 +82,10 @@ module.exports = function nodeExternals(options) {
     var whitelist = [].concat(options.whitelist || []);
     var binaryDirs = [].concat(options.binaryDirs || ['.bin']);
     var importType = options.importType || 'commonjs';
+    // `modulesDir` is kept for Backward compatibility as
+    // it can be replaced by modulesDirs = ['node_modules']
     var modulesDir = options.modulesDir || 'node_modules';
+    var modulesDirs = options.modulesDirs || [modulesDir];
     var modulesFromFile = !!options.modulesFromFile;
     var includeAbsolutePaths = !!options.includeAbsolutePaths;
 
@@ -92,7 +95,9 @@ module.exports = function nodeExternals(options) {
     }
 
     // create the node modules list
-    var nodeModules = modulesFromFile ? readFromPackageJson() : readDir(modulesDir).filter(isNotBinary);
+    var nodeModules = modulesFromFile ? readFromPackageJson() : modulesDirs.reduce(
+      function (dirs, dir) { return dirs.concat(readDir(dir).filter(isNotBinary))}, []
+    );
 
     // return an externals function
     return function(context, request, callback){

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "mocha": "^2.5.3",
     "mock-fs-require-fix": "^1.0.1",
     "ncp": "^2.0.0",
-    "webpack": "^1.13.1"
+    "webpack": "^1.13.1",
+    "clone": "^2.1.1"
   },
   "scripts": {
     "unit": "mocha --colors ./test/*.spec.js",

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,4 +1,5 @@
 var mockDir = require('mock-fs-require-fix');
+var clone = require('clone');
 var nodeExternals = require('../index.js');
 var webpack = require('webpack');
 var fs = require('fs');
@@ -24,6 +25,29 @@ exports.buildAssertion = function buildAssertion(context, moduleName, expectedRe
     };
 }
 
+const defaultNodeModulesStructure = {
+  'moduleA' : {
+      'sub-module':{},
+      'another-sub':{
+          'index.js' : ''
+      },
+  },
+  'moduleB' : {
+      'sub-module':{}
+  },
+  'moduleC' : {},
+  'moduleD' : {
+      'sub-module':{}
+  },
+  'moduleF' : {},
+  '@organisation/moduleA':{},
+  '@organisation/base-node':{},
+};
+
+exports.getDefaultNodeModulesStructure = function() {
+  return clone(defaultNodeModulesStructure);
+};
+
 /**
  * Mocks the fs module to output a desired structure
  * @param  {object} structure       the requested structure
@@ -31,38 +55,22 @@ exports.buildAssertion = function buildAssertion(context, moduleName, expectedRe
  */
 exports.mockNodeModules = function mockNodeModules(structure){
     structure = structure || {
-        'moduleA' : {
-            'sub-module':{},
-            'another-sub':{
-                'index.js' : ''
-            },
-        },
-        'moduleB' : {
-            'sub-module':{}
-        },
-        'moduleC' : {},
-        'moduleD' : {
-            'sub-module':{}
-        },
-        'moduleF' : {},
-        '@organisation/moduleA':{},
-        '@organisation/base-node':{},
+      'node_modules': defaultNodeModulesStructure,
     };
 
-    mockDir({
-        'node_modules' : structure,
-        'package.json': JSON.stringify({
-            dependencies: {
-                'moduleE': '1.0.0',
-                'moduleF': '1.0.0',
-                '@organisation/moduleE': '1.0.0',
-            },
-            devDependencies: {
-                'moduleG': '1.0.0',
-                '@organisation/moduleG': '1.0.0',
-            },            
-        })
+    structure['package.json'] = JSON.stringify({
+      dependencies: {
+          'moduleE': '1.0.0',
+          'moduleF': '1.0.0',
+          '@organisation/moduleE': '1.0.0',
+      },
+      devDependencies: {
+          'moduleG': '1.0.0',
+          '@organisation/moduleG': '1.0.0',
+      },
     });
+
+    mockDir(structure);
 }
 
 /**


### PR DESCRIPTION
This commit introduces the `modulesDirs` option to allow multiple modules directory to be specified. This is useful in case your modules are spread in different folders (e.g. yarn workspaces).

This relates to https://github.com/liady/webpack-node-externals/issues/39, https://github.com/liady/webpack-node-externals/issues/32

- [x] Fixed Travis CI by removing useless before_install script
- [x] Introduced `modulesDirs` options