### PR TITLE
Add Yarn workspace support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 var fs = require("fs");
 var path = require("path");
+var findRoot = require("find-root");
+var micromatch = require("micromatch");
 
 var scopedModuleRegex = new RegExp('@[a-zA-Z0-9][\\w-.]+\/[a-zA-Z0-9][\\w-.]+([a-zA-Z0-9.\/]+)?', 'g');
 var atPrefix = new RegExp('^@', 'g');
@@ -7,14 +9,80 @@ function contains(arr, val) {
     return arr && arr.indexOf(val) !== -1;
 }
 
-function readDir(dirName) {
+/**
+ * Checks if we are running in a Yarn workspace
+ * and if so returns the path to the root of the workspace.
+ */
+function findYarnWorkspaceRoot() {
     try {
-        return fs.readdirSync(dirName).map(function(module) {
+        // Figure out the current root of the working directory.
+        const processRoot = findRoot(process.cwd());
+
+        // To find the workspace root, if any, we recursively look for package.json files
+        // and check if they contain the workspaces array required by Yarn.
+        // If we found such a package.json we'll check if this module is currently one of those workspaces.
+        const workspaceRoot = findRoot(processRoot, function (dir) {
+            const possiblePackageJSONPath = path.join(dir, "./package.json");
+
+            if (!fs.existsSync(possiblePackageJSONPath)) {
+                return false;
+            }
+
+            // We found a package.json so let's check for the workspaces array.
+            const packageJSON = JSON.parse(fs.readFileSync(possiblePackageJSONPath));
+            const containsWorkspaces =
+                !!packageJSON.workspaces && Array.isArray(packageJSON.workspaces);
+
+            if (!containsWorkspaces) {
+                return false;
+            }
+
+            // All that's left is check this module is a workspace.
+            // We do this by checking if our relative path matches one of the workspace globs.
+            const relativeProcessRoot = path
+                .relative(dir, processRoot)
+                .replace(/\\/gi, "/"); // ensure all slashes are consistent and valid for glob matching.
+
+            const matchingWorkspace = packageJSON.workspaces.find(function (
+                workspace
+            ) {
+                const validWorkspace = workspace.replace(/\\/gi, "/"); // again, slashes should be consistent.
+                return micromatch.isMatch(relativeProcessRoot, validWorkspace);
+            });
+
+            return !!matchingWorkspace;
+        });
+
+        return workspaceRoot;
+    } catch (e) {
+        // We went up so far that findRoot eventually returned an error
+        // or we aren't even runninng in a working directory that contains a package.json,
+        // default to no workspace.
+        return null;
+    }
+}
+
+
+
+function readDir(dirName) {	
+    try {
+		// When running in a Yarn workspace, just looking for node_modules won't work
+        // because Yarn keeps the entire node_modules list at the root of all workspaces.
+        // This is why we first have to figure out if we are running in a workspace.
+        // If we are running in a workspace we have to look into the node_modules of the Yarn root.
+        const rootPackageWithWorkspaces = findYarnWorkspaceRoot();
+        const usingYarnWorkspaces = !!rootPackageWithWorkspaces;
+
+        const nodeModulesRootDir = usingYarnWorkspaces
+            ? path.join(rootPackageWithWorkspaces, dirName)
+            : dirName;
+		
+        return fs.readdirSync(nodeModulesRootDir).map(function(module) {
             if (atPrefix.test(module)) {
                 // reset regexp
                 atPrefix.lastIndex = 0;
                 try {
-                    return fs.readdirSync(path.join(dirName, module)).map(function(scopedMod) {
+                    return fs.readdirSync(path.join(nodeModulesRootDir, module)).map(function(scopedMod) {
                         return module + '/' + scopedMod;
                     });
                 } catch (e) {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,10 @@
     "type": "git",
     "url": "https://github.com/liady/webpack-node-externals.git"
   },
-  "dependencies": {},
+  "dependencies": {
+    "find-root": "^1.1.0",
+    "micromatch": "^3.1.9"
+  },
   "devDependencies": {
     "chai": "^3.5.0",
     "mocha": "^2.5.3",


### PR DESCRIPTION
Hi,

When migrating one of my own repositories to a mono-repo style I hit an issue where `webpack` would keep bundling my `node_modules` even though I was using `webpack-node-externals`.

After some deep digging I eventually figured out that it was because I was using the 
[Yarn workspaces](https://yarnpkg.com/lang/en/docs/workspaces) feature. This causes Yarn to keep all `node_modules` at the top-level of where you defined your workspace root.

This pull request fixes this issue. I pulled in two additional dependencies for this:
* [find-root](https://www.npmjs.com/package/find-root): To aid in recursively looking for the workspace root
* [micromatch](https://www.npmjs.com/package/micromatch): To match the Yarn workspace globs

If issue is too much of an edge case, I understand. There are other work-arounds for this (although they pretty much require you to fallback to reading from your package.json dependency list or by manually defining every module you depend on). 

I've used this fix for myself in my migrated mono-repo and figured I would at least share the code.

I had no good idea for a realistic test in the test-suite, but I'm open for feedback.