### PR TITLE
Do not log error when node_modules does not exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 before_install:
   - "npm install npm -g"
 node_js:
-  - "0.12"
   - 5
   - 6
 env:

--- a/index.js
+++ b/index.js
@@ -8,6 +8,10 @@ function contains(arr, val) {
 }
 
 function readDir(dirName) {
+    if (!fs.existsSync(dirName)) {
+        return [];
+    }
+
     try {
         return fs.readdirSync(dirName).map(function(module) {
             if (atPrefix.test(module)) {

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -4,6 +4,8 @@ var mockNodeModules = testUtils.mockNodeModules;
 var restoreMock = testUtils.restoreMock;
 var context={};
 var assertResult = testUtils.buildAssertion.bind(null, context);
+var chai = require('chai');
+var expect = chai.expect;
 
 // Test basic functionality
 describe('invocation with no settings', function() {
@@ -172,3 +174,39 @@ describe('invocation with an absolute path setting', function() {
         restoreMock()
     });
 });
+
+describe('when modules dir does not exist', function() {
+    before(function() {
+        mockNodeModules();
+    })
+    it('should not log ENOENT error', function() {
+        const log = global.console.log;
+        let errorLogged = false;
+
+        // wrap console.log to catch error message
+        global.console.log = function(error) {
+            if (error instanceof Error && error.message.indexOf("ENOENT, no such file or directory 'node_modules/somepackage/node_modules") !== -1) {
+                errorLogged = true;
+            }
+            log.apply(null, arguments);
+        }
+
+        context.instance = nodeExternals({
+            modulesDir: 'node_modules/somepackage/node_modules'
+        });
+
+        // cleanup specific testcase env changes
+        global.console.log = log;
+
+        expect(errorLogged, 'ENOENT not logged').to.be.equal(false);
+    });
+    it('should process like node_modules is empty', function(done) {
+        context.instance = nodeExternals({
+            modulesDir: 'node_modules/somepackage/node_modules'
+        });
+        testUtils.buildAssertion(context, 'somepackage', undefined)(done);
+    });
+    after(function(){
+        restoreMock()
+    });
+})

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -180,8 +180,8 @@ describe('when modules dir does not exist', function() {
         mockNodeModules();
     })
     it('should not log ENOENT error', function() {
-        const log = global.console.log;
-        let errorLogged = false;
+        var log = global.console.log;
+        var errorLogged = false;
 
         // wrap console.log to catch error message
         global.console.log = function(error) {


### PR DESCRIPTION
*webpack-node-externals* logs annoying error when *modulesDir* (default is node_modules) does not exist.
described in #44 

This PR check if modulesDir exist. If it does, *webpack-node-externals*  will work as before. If it does not *webpack-node-externals* will return `[]` as modulesList without logging error.