### PR TITLE
Allow absolute paths in fileName

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Read the modules from the `package.json` file instead of the `node_modules` fold
     modulesFromFile: true,
     /* or */
     modulesFromFile: {
+        fileName: /* path to package.json to read from */,
         exclude: [/* sections to exclude, i.e 'devDependencies' */],
         include: [/* sections to explicitly include, i.e only 'dependencies' */]
     }

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function nodeExternals(options) {
     }
 
     // create the node modules list
-    var nodeModules = modulesFromFile ? utils.readFromPackageJson(modulesFromFile) : utils.readDir(modulesDir).filter(isNotBinary);
+    var nodeModules = modulesFromFile ? utils.readFromPackageJson(options.modulesFromFile) : utils.readDir(modulesDir).filter(isNotBinary);
 
     // return an externals function
     return function(context, request, callback){

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function nodeExternals(options) {
     }
 
     // create the node modules list
-    var nodeModules = modulesFromFile ? utils.readFromPackageJson(options.modulesFromFile) : utils.readDir(modulesDir).filter(isNotBinary);
+    var nodeModules = modulesFromFile ? utils.readFromPackageJson(modulesFromFile) : utils.readDir(modulesDir).filter(isNotBinary);
 
     // return an externals function
     return function(context, request, callback){

--- a/utils.js
+++ b/utils.js
@@ -41,7 +41,7 @@ exports.readFromPackageJson = function readFromPackageJson(options) {
     var packageJson;
     try {
         var fileName = options.fileName || 'package.json';
-        var packageJsonString = fs.readFileSync(path.join(process.cwd(), './' + fileName), 'utf8');
+        var packageJsonString = fs.readFileSync(path.resolve(process.cwd(), fileName), 'utf8');
         packageJson = JSON.parse(packageJsonString);
     } catch (e){
         return [];


### PR DESCRIPTION
Tested with `node`:
```js
const utils = require('./utils')
utils.readFromPackageJson()
utils.readFromPackageJson({ fileName: 'package.json' })
utils.readFromPackageJson({ fileName: '/Users/bchinn/repos/webpack-node-externals/package.json' })
```