### PR TITLE
Replace "whitelist" option with "allowlist"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ This library scans the `node_modules` folder for all node_modules names, and bui
 ### Configuration
 This library accepts an `options` object.
 
-#### `options.whitelist (=[])`
-An array for the `externals` to whitelist, so they **will** be included in the bundle. Can accept exact strings (`'module_name'`), regex patterns (`/^module_name/`), or a function that accepts the module name and returns whether it should be included.
-<br/>**Important** - if you have set aliases in your webpack config with the exact same names as modules in *node_modules*, you need to whitelist them so Webpack will know they should be bundled.
+#### `options.allowlist (=[])`
+An array for the `externals` to allow, so they **will** be included in the bundle. Can accept exact strings (`'module_name'`), regex patterns (`/^module_name/`), or a function that accepts the module name and returns whether it should be included.
+<br/>**Important** - if you have set aliases in your webpack config with the exact same names as modules in *node_modules*, you need to allowlist them so Webpack will know they should be bundled.
 
 #### `options.importType (='commonjs')`
 The method in which unbundled modules will be required in the code. Best to leave as `commonjs` for node modules.
@@ -75,7 +75,7 @@ module.exports = {
     target: 'node', // important in order not to bundle built-in modules like path, fs, etc.
     externals: [nodeExternals({
         // this WILL include `jquery` and `webpack/hot/dev-server` in the bundle, as well as `lodash/*`
-        whitelist: ['jquery', 'webpack/hot/dev-server', /^lodash/]
+        allowlist: ['jquery', 'webpack/hot/dev-server', /^lodash/]
     })],
     ...
 };
@@ -99,12 +99,12 @@ However, this will leave unbundled **all non-relative requires**, so it does not
 This library scans the `node_modules` folder, so it only leaves unbundled the actual node modules that are being used.
 
 #### How can I bundle required assets (i.e css files) from node_modules?
-Using the `whitelist` option, this is possible. We can simply tell Webpack to bundle all files with extensions that are not js/jsx/json, using this [regex](https://regexper.com/#%5C.(%3F!(%3F%3Ajs%7Cjson)%24).%7B1%2C5%7D%24):
+Using the `allowlist` option, this is possible. We can simply tell Webpack to bundle all files with extensions that are not js/jsx/json, using this [regex](https://regexper.com/#%5C.(%3F!(%3F%3Ajs%7Cjson)%24).%7B1%2C5%7D%24):
 ```js
 ...
 nodeExternals({
   // load non-javascript files with extensions, presumably via loaders
-  whitelist: [/\.(?!(?:jsx?|json)$).{1,5}$/i],
+  allowlist: [/\.(?!(?:jsx?|json)$).{1,5}$/i],
 }),
 ...
 ```

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function getModuleName(request, includeAbsolutePaths) {
 
 module.exports = function nodeExternals(options) {
     options = options || {};
-    var whitelist = [].concat(options.whitelist || []);
+    var allowlist = [].concat(options.allowlist || []);
     var binaryDirs = [].concat(options.binaryDirs || ['.bin']);
     var importType = options.importType || 'commonjs';
     var modulesDir = options.modulesDir || 'node_modules';
@@ -38,7 +38,7 @@ module.exports = function nodeExternals(options) {
     // return an externals function
     return function(context, request, callback){
         var moduleName = getModuleName(request, includeAbsolutePaths);
-        if (utils.contains(nodeModules, moduleName) && !utils.containsPattern(whitelist, request)) {
+        if (utils.contains(nodeModules, moduleName) && !utils.containsPattern(allowlist, request)) {
             if (typeof importType === 'function') {
                 return callback(null, importType(request));
             }

--- a/test/library.spec.js
+++ b/test/library.spec.js
@@ -132,13 +132,13 @@ describe('reads from a file', function() {
     });
 });
 
-// Test whitelist
-describe('respects a whitelist', function() {
+// Test allowlist
+describe('respects a allowlist', function() {
 
     before(function(){
         mockNodeModules();
         context.instance = nodeExternals({
-            whitelist: ['moduleA/sub-module', 'moduleA/another-sub/index.js', 'moduleC', function (m) {
+            allowlist: ['moduleA/sub-module', 'moduleA/another-sub/index.js', 'moduleC', function (m) {
                 return m == 'moduleF';
             }, /^moduleD/]
         });

--- a/test/webpack.spec.js
+++ b/test/webpack.spec.js
@@ -11,14 +11,14 @@ describe('actual webpack bundling', function() {
 
     describe('basic tests', function() {
         it('should output modules without bundling', webpackAssertion({}, ['module-a', 'module-b'], ['module-c']));
-        it('should honor a whitelist', webpackAssertion({ whitelist: ['module-a'] }, ['module-b'], ['module-a', 'module-c']));
+        it('should honor a allowlist', webpackAssertion({ allowlist: ['module-a'] }, ['module-b'], ['module-a', 'module-c']));
     });
 
     describe('with webpack aliased module in node_modules', function() {
         before(function() {
             return testUtils.copyModules(['module-c']);
         });
-        it('should bundle aliased modules', webpackAssertion({ whitelist: ['module-c'] }, ['module-a', 'module-b'], ['module-c']));
+        it('should bundle aliased modules', webpackAssertion({ allowlist: ['module-c'] }, ['module-a', 'module-b'], ['module-c']));
     })
 
     after(function() {


### PR DESCRIPTION
Hello again!

We use this library as a development dependency over at [Opentrons/opentrons](https://github.com/Opentrons/opentrons/blob/2134b97468d1f45ed35425b3d5f15dfdeb195bdf/webpack-config/lib/node-base-config.js#L35-L40). We're currently in the process of [cleaning up some language in our codebase](https://github.com/Opentrons/opentrons/pull/5905) to be more inclusive and welcoming.

We'd like to remove the terms "whitelist" and "blacklist" from our codebase, but unfortunately, this library uses the term "whitelist" as part of its public API. [This IETF RFC on "Terminology, Power and Offensive Language"](https://tools.ietf.org/id/draft-knodel-terminology-01.html#rfc.section.1.2) has a great writeup of why these terms, despite how extremely common they are in technical context, are not truly technical terms and insidiously promote harmful racial tropes.

This PR replaces `options.whitelist` with the more technically accurate `options.allowlist`, per the recommendation of that IETF document. I hope you'll consider this PR to help us foster a more inclusive and welcoming open-source community!

This PR is a **BREAKING CHANGE** due to the change in the public options API and would require a 2.0.0 release of this library.

This PR is also not going to pass CI until #74 is merged, because CI is configured to run tests on "whatever the latest Node LTS version is".