### PR TITLE
fix: Add support for webpack 5 module federation references

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function nodeExternals(options) {
             utils.log(mistake.message);
         });
     }
-    var allowlist = [].concat(options.allowlist || [/^webpack\/container\/reference\//]);
+    var allowlist = [/^webpack\/container\/reference\//].concat(options.allowlist || []);;
     var binaryDirs = [].concat(options.binaryDirs || ['.bin']);
     var importType = options.importType || 'commonjs';
     var modulesDir = options.modulesDir || 'node_modules';

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function nodeExternals(options) {
             utils.log(mistake.message);
         });
     }
-    var allowlist = [].concat(options.allowlist || []);
+    var allowlist = [].concat(options.allowlist || [/^webpack\/container\/reference\//]);
     var binaryDirs = [].concat(options.binaryDirs || ['.bin']);
     var importType = options.importType || 'commonjs';
     var modulesDir = options.modulesDir || 'node_modules';


### PR DESCRIPTION
Without this webpack tries to import an external called "webpack/container/reference/xxx" that does not exist when referencing a federated remote.