### PR TITLE
Include type declarations in package

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,18 @@ function getModuleName(request, includeAbsolutePaths) {
     return req.split(delimiter)[0];
 }
 
+/**
+ * @param {{
+ *   additionalModuleDirs?: string[];
+ *   allowlist?: string | RegExp | ((moduleName: string) => boolean) | (string | RegExp | ((moduleName: string) => boolean))[];
+ *   binaryDirs?: string[];
+ *   importType?: 'amd' | 'commonjs' | 'this' | 'umd' | 'var' | ((moduleName: string) => string);
+ *   includeAbsolutePaths?: boolean;
+ *   modulesDir?: string;
+ *   modulesFromFile?: boolean | { exclude?: string | string[]; include?: string | string[]; };
+ * }} [options]
+ * @returns (...args: any[]) => any
+ */
 module.exports = function nodeExternals(options) {
     options = options || {};
     const mistakes = utils.validateOptions(options) || [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -789,6 +789,15 @@
           "requires": {
             "brace-expansion": "^1.1.7"
           }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
         }
       }
     },
@@ -1073,6 +1082,40 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "copy-descriptor": {
@@ -2916,6 +2959,40 @@
         "mkdirp": "^0.5.1",
         "rimraf": "^2.5.4",
         "run-queue": "^1.0.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "ms": {
@@ -3594,9 +3671,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
@@ -4324,6 +4401,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "union-value": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "3.0.0",
     "description": "Easily exclude node_modules in Webpack bundle",
     "main": "index.js",
+    "types": "types/index.d.ts",
     "repository": {
         "type": "git",
         "url": "https://github.com/liady/webpack-node-externals.git"
@@ -15,12 +16,16 @@
         "mocha": "^2.5.3",
         "mock-fs": "^4.12.0",
         "ncp": "^2.0.0",
+        "rimraf": "^3.0.2",
+        "typescript": "^4.2.4",
         "webpack": "^4.44.1"
     },
     "scripts": {
         "unit": "mocha --colors ./test/*.spec.js",
         "unit-watch": "mocha --colors -w ./test/*.spec.js",
-        "test": "npm run unit-watch"
+        "test": "npm run unit-watch",
+        "pretypes": "rimraf ./types/",
+        "types": "tsc"
     },
     "keywords": [
         "webpack",
@@ -37,6 +42,7 @@
         "LICENSE",
         "README.md",
         "index.js",
+        "types/*",
         "utils.js"
     ],
     "bugs": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "declaration": true,
+    "declarationDir": "types",
+    "emitDeclarationOnly": true
+  },
+  "include": [ "index.js" ]
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,13 @@
+declare function _exports(options?: {
+    additionalModuleDirs?: string[];
+    allowlist?: string | RegExp | ((moduleName: string) => boolean) | (string | RegExp | ((moduleName: string) => boolean))[];
+    binaryDirs?: string[];
+    importType?: "var" | "amd" | "commonjs" | "this" | "umd" | ((moduleName: string) => string);
+    includeAbsolutePaths?: boolean;
+    modulesDir?: string;
+    modulesFromFile?: boolean | {
+        exclude?: string | string[];
+        include?: string | string[];
+    };
+}): (...args: any[]) => any;
+export = _exports;

--- a/types/utils.d.ts
+++ b/types/utils.d.ts
@@ -1,0 +1,8 @@
+export function contains(arr: any, val: any): boolean;
+export function readDir(dirName: any): any;
+export function readFromPackageJson(options: any): string[];
+export function containsPattern(arr: any, val: any): any;
+export function validateOptions(options: any): any[];
+export function log(message: any): void;
+export function error(errors: any): never;
+export function getFilePath(options: any): any;


### PR DESCRIPTION
Fixes #105 

Adds JSDoc to allow declaration files to be generated by `tsc`. TypeScript users would no longer be required to install `@types/webpack-node-externals`.